### PR TITLE
EOF on exit

### DIFF
--- a/lib/ladle/server.rb
+++ b/lib/ladle/server.rb
@@ -283,7 +283,7 @@ module Ladle
       end
 
       def watch
-        while (line = @ds_out.readline) && !error?
+        while ( !@ds_out.eof? && line = @ds_out.readline ) && !error?
           case line
           when /^STARTED/
             @started = true


### PR DESCRIPTION
Avoid EOF error on server.stop

```
/Users/iRyusa/.rvm/gems/ruby-2.0.0-p247/gems/ladle-0.2.0/lib/ladle/server.rb:281:in `readline': end of file reached (EOFError)
    from /Users/iRyusa/.rvm/gems/ruby-2.0.0-p247/gems/ladle-0.2.0/lib/ladle/server.rb:281:in `watch'
    from /Users/iRyusa/.rvm/gems/ruby-2.0.0-p247/gems/ladle-0.2.0/lib/ladle/server.rb:276:in `block in start'
```
