### PR TITLE
Ruby has a method for detecting temp directory.

### DIFF
--- a/lib/ladle/server.rb
+++ b/lib/ladle/server.rb
@@ -1,4 +1,5 @@
 require 'ladle'
+require 'tmpdir'
 
 module Ladle
   ##
@@ -90,7 +91,7 @@ module Ladle
       @quiet = opts[:quiet]
       @verbose = opts[:verbose]
       @timeout = opts[:timeout] || 60
-      @tmpdir = opts[:tmpdir] || ENV['TMPDIR'] || ENV['TEMPDIR']
+      @tmpdir = opts[:tmpdir] || ENV['TEMPDIR'] || Dir.tmpdir
       @java_bin = opts[:java_bin] ||
         (ENV['JAVA_HOME'] ? File.join(ENV['JAVA_HOME'], "bin", "java") : "java")
       @custom_schemas = opts[:custom_schemas] ? [*opts[:custom_schemas]] : []
@@ -105,9 +106,7 @@ module Ladle
         raise "The domain component must start with 'dc='.  '#{@domain}' does not."
       end
 
-      if tmpdir.nil?
-        raise "Cannot guess tmpdir from the environment.  Please specify it."
-      elsif !File.directory?(tmpdir)
+      unless File.directory?(tmpdir)
         raise "Tmpdir #{tmpdir.inspect} does not exist."
       end
 

--- a/spec/ladle/server_spec.rb
+++ b/spec/ladle/server_spec.rb
@@ -149,14 +149,13 @@ describe Ladle, "::Server" do
           should == tmpdir('zap')
       end
 
+      it "must be specified somehow" do
+        Ladle::Server.new.tmpdir.should == Dir.tmpdir
+      end
+
       it "must exist" do
         lambda { Ladle::Server.new(:tmpdir => 'whatever') }.
           should raise_error(/Tmpdir "whatever" does not exist./)
-      end
-
-      it "must be specified somehow" do
-        lambda { Ladle::Server.new }.
-          should raise_error(/Cannot guess tmpdir from the environment.  Please specify it./)
       end
     end
 


### PR DESCRIPTION
It uses `ENV['TMPDIR'], ENV['TMP'], ENV['TEMP'], @@systmpdir, '/tmp', '.'`, so I left `ENV['TEMPDIR']` as is and let stdlib to handle the rest.
This is more convenient to write tests that don't specify tmpdir, since it may vary on different machines, while the pre-existing method wasn't detecting them that good.
