### PR TITLE
Treat unrecognized attributeType as bogus warning

### DIFF
--- a/lib/ladle/server.rb
+++ b/lib/ladle/server.rb
@@ -374,7 +374,8 @@ module Ladle
           %r{attributeType w/ OID 2.5.4.16 not registered},
           %r{default.*?cache size},
           %r{change the admin password},
-          %r{Attribute \S+ does not have normalizer}
+          %r{Attribute \S+ does not have normalizer},
+          %r{attribute \S+ was not recognized as a valid attributeType}
         ].detect { |re| line =~ re }
       end
     end


### PR DESCRIPTION
This can happen when searching and requesting attributes that are not recognized.

For example, the Net::LDAP Ruby library searches for `supportedCapabilities`
attribute when pulling back the Root DSE entry, producing this warning:

```
The attribute supportedCapabilities was not recognized as a valid attributeType.
```

As far as I can discern, unrecognized attribute types should be ignored by the
server. See:
https://tools.ietf.org/html/rfc4511#section-4.5.1.7
https://tools.ietf.org/html/rfc4511#section-4.5.1.8
